### PR TITLE
Align deploy template paths with /app/sandwicheck

### DIFF
--- a/scripts/deploy/redeploy.config.example
+++ b/scripts/deploy/redeploy.config.example
@@ -6,7 +6,7 @@
 #   cp scripts/deploy/redeploy.config.example scripts/deploy/redeploy.config
 
 # Absolute path to the cloned repo (default: two levels up from scripts/deploy/).
-# REPO_DIR=/opt/sandwicheck/SandwiCheck
+# REPO_DIR=/app/sandwicheck
 
 # Git branch to track and deploy (default: main, kept CI-clean via branch protection).
 # BRANCH=main
@@ -23,11 +23,11 @@
 
 # Production env file the container reads (Atlas MONGO_URI, JWT_SECRET, mail, ...).
 # Template: apps/server/config/.env.example
-# ENV_FILE=/opt/sandwicheck/SandwiCheck/apps/server/config/.env
+# ENV_FILE=/app/sandwicheck/apps/server/config/.env
 
 # Host directory bind-mounted for stateful uploads + generated sandwich/ingredient
 # images. Persists across rebuilds.
-# UPLOADS_DIR=/opt/sandwicheck/SandwiCheck/apps/server/uploads
+# UPLOADS_DIR=/app/sandwicheck/apps/server/uploads
 
 # How many 2s health-check polls to wait after (re)starting the container.
 # HEALTH_RETRIES=30
@@ -38,5 +38,5 @@
 # ---------------------------------------------------------------------------
 # Cron alternative to the systemd timer (run every 5 minutes, log to a file):
 #   crontab -e
-#   */5 * * * * /opt/sandwicheck/SandwiCheck/scripts/deploy/redeploy.sh >> /var/log/sandwicheck-redeploy.log 2>&1
+#   */5 * * * * /app/sandwicheck/scripts/deploy/redeploy.sh >> /var/log/sandwicheck-redeploy.log 2>&1
 # ---------------------------------------------------------------------------

--- a/scripts/deploy/redeploy.sh
+++ b/scripts/deploy/redeploy.sh
@@ -21,7 +21,7 @@
 #         # Docker: https://docs.docker.com/engine/install/debian/
 #         sudo usermod -aG docker "$USER"   # then re-login
 #   2.  Clone the repo (it deploys the default branch, main):
-#         git clone <repo> /opt/sandwicheck/SandwiCheck
+#         git clone <repo> /app/sandwicheck
 #   3.  Create the production env file from the template and fill MONGO_URI (Atlas),
 #       JWT_SECRET, mail creds, etc. Keep PORT=5001 to match the image HEALTHCHECK:
 #         cp apps/server/config/.env.example apps/server/config/.env && edit it

--- a/scripts/deploy/sandwicheck-redeploy.service
+++ b/scripts/deploy/sandwicheck-redeploy.service
@@ -20,11 +20,11 @@ Type=oneshot
 # Runs as root to match the current box (Docker daemon is root; rootless is deferred).
 # To drop privilege later, create a dedicated user and point this at it:
 #   useradd -r -s /usr/sbin/nologin -G docker deploy
-#   chown -R deploy:deploy /opt/sandwicheck/SandwiCheck
+#   chown -R deploy:deploy /app/sandwicheck
 #   then set User=deploy  (note: 'docker' group membership is still root-equivalent —
 #   real isolation comes from rootless Docker).
 User=root
 # EDIT: absolute path to the script on this server.
-ExecStart=/opt/sandwicheck/SandwiCheck/scripts/deploy/redeploy.sh
+ExecStart=/app/sandwicheck/scripts/deploy/redeploy.sh
 # Give the image build + health wait room to finish.
 TimeoutStartSec=900


### PR DESCRIPTION
The systemd unit and redeploy config templates shipped the placeholder /opt/sandwicheck/SandwiCheck path, which doesn't match where the repo is actually cloned on the server (/app/sandwicheck). Installing the unit verbatim caused the redeploy.service to fail with 203/EXEC (no such executable). Point the defaults at the real deploy location.