### PR TITLE
Fix/critical bugs and hardening

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -75,6 +75,9 @@ jobs:
       - name: Lint
         run: pnpm lint
 
+      - name: Test (server)
+        run: pnpm --filter @sandwicheck/server run test
+
   # Client: verify it tests and builds. No artifact is kept — the Pages build is
   # produced by deploy-to-pages.yml, so there's nothing to hand off here.
   client:

--- a/apps/client/src/components/Sandwich/Card/SandwichCard.tsx
+++ b/apps/client/src/components/Sandwich/Card/SandwichCard.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react';
 import { Link, useNavigate } from '@tanstack/react-router';
 import SandwichImage from '@/components/Sandwich/SandwichImage';
-import SignupModal from '@/components/Signup/SignupModal';
 import { ROUTE_PATHS } from '@/constants/route-paths';
 import { useAuthGlobalContext } from '@/context/AuthGlobalContext';
 import { useIngredientsGlobalContext } from '@/context/IngredientsGlobalContext';
@@ -20,13 +19,12 @@ interface SandwichCardProps {
 }
 
 const SandwichCard = ({ index, sandwich, galleryPath = '', isModal }: SandwichCardProps): React.JSX.Element => {
-  const { currentUser, setCurrentUser } = useAuthGlobalContext();
+  const { currentUser, setCurrentUser, openSignupPrompt } = useAuthGlobalContext();
   const { ingredientsRawList } = useIngredientsGlobalContext();
   const { showToast, toastComponents } = useToast();
 
   const [votesCount, setVotesCount] = useState(sandwich.votesCount);
   const [isProcessingVote, setIsProcessingVote] = useState(false);
-  const [isSignupOpen, setIsSignupOpen] = useState(false);
   const [isOptimisticallyVoted, setIsOptimisticallyVoted] = useState(() =>
     hasUserVotedForSandwich(sandwich, currentUser),
   );
@@ -69,9 +67,9 @@ const SandwichCard = ({ index, sandwich, galleryPath = '', isModal }: SandwichCa
       return;
     }
 
-    // Voting requires an account — send logged-out visitors to signup instead.
+    // Voting requires an account — open the app-level signup prompt for logged-out visitors.
     if (!currentUser.id) {
-      setIsSignupOpen(true);
+      openSignupPrompt();
       return;
     }
 
@@ -208,7 +206,6 @@ const SandwichCard = ({ index, sandwich, galleryPath = '', isModal }: SandwichCa
       </div>
 
       {isModal && <SandwichIngredientsList sandwich={sandwich} ingredientsRawList={ingredientsRawList} />}
-      {isSignupOpen && <SignupModal setIsOpenLoginModal={setIsSignupOpen} closeLink="stay" />}
       {toastComponents}
     </div>
   );

--- a/apps/client/src/components/Sandwich/Card/SandwichCard.tsx
+++ b/apps/client/src/components/Sandwich/Card/SandwichCard.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Link, useNavigate } from '@tanstack/react-router';
 import SandwichImage from '@/components/Sandwich/SandwichImage';
+import SignupModal from '@/components/Signup/SignupModal';
 import { ROUTE_PATHS } from '@/constants/route-paths';
 import { useAuthGlobalContext } from '@/context/AuthGlobalContext';
 import { useIngredientsGlobalContext } from '@/context/IngredientsGlobalContext';
@@ -25,6 +26,7 @@ const SandwichCard = ({ index, sandwich, galleryPath = '', isModal }: SandwichCa
 
   const [votesCount, setVotesCount] = useState(sandwich.votesCount);
   const [isProcessingVote, setIsProcessingVote] = useState(false);
+  const [isSignupOpen, setIsSignupOpen] = useState(false);
   const [isOptimisticallyVoted, setIsOptimisticallyVoted] = useState(() =>
     hasUserVotedForSandwich(sandwich, currentUser),
   );
@@ -67,22 +69,27 @@ const SandwichCard = ({ index, sandwich, galleryPath = '', isModal }: SandwichCa
       return;
     }
 
+    // Voting requires an account — send logged-out visitors to signup instead.
     if (!currentUser.id) {
-      showToast('Please log in to vote for sandwiches');
+      setIsSignupOpen(true);
       return;
     }
 
     setIsProcessingVote(true);
 
     try {
-      const response = await voteForSandwich({ userId: currentUser.id, sandwichId: sandwich.id });
+      /*
+       * One authenticated call both casts the vote and adds the sandwich to the user's
+       * favorites (the server owns and keeps them in sync). Reflect both locally.
+       */
+      const voteResponse = await voteForSandwich({ sandwichId: sandwich.id });
 
-      if (!response?.success) {
-        showToast(response?.error?.message || 'Unable to add this sandwich to your favorites');
+      if (!voteResponse?.success) {
+        showToast(voteResponse?.error?.message || 'Unable to register your vote right now.');
         return;
       }
 
-      setVotesCount((prev) => response?.data?.votesCount ?? prev + 1);
+      setVotesCount((prev) => voteResponse.data?.votesCount ?? prev + 1);
       setIsOptimisticallyVoted(true);
 
       setCurrentUser((previousUser) => {
@@ -99,7 +106,7 @@ const SandwichCard = ({ index, sandwich, galleryPath = '', isModal }: SandwichCa
         };
       });
     } catch (error) {
-      const fallbackMessage = extractErrorMessage(error) || 'Unable to add this sandwich to your favorites';
+      const fallbackMessage = extractErrorMessage(error) || 'Unable to register your vote right now.';
       showToast(fallbackMessage);
     } finally {
       setIsProcessingVote(false);
@@ -108,11 +115,9 @@ const SandwichCard = ({ index, sandwich, galleryPath = '', isModal }: SandwichCa
 
   return (
     <div
-      // FIXME: implement voted class from real data
-      // eslint-disable-next-line no-constant-binary-expression
-      className={`sandwich-card ${true && 'voted'} ${
+      className={`sandwich-card ${isVotedByUser ? 'voted' : ''} ${
         isModal
-          ? 'thumb modal__thumb voted flex flex-col justify-center md:flex-row'
+          ? 'thumb modal__thumb flex flex-col justify-center md:flex-row'
           : 'thumb xxl:w-1/5 flex w-1/2 sm:w-1/2 lg:w-1/3 xl:w-1/4'
       }`}
     >
@@ -203,6 +208,7 @@ const SandwichCard = ({ index, sandwich, galleryPath = '', isModal }: SandwichCa
       </div>
 
       {isModal && <SandwichIngredientsList sandwich={sandwich} ingredientsRawList={ingredientsRawList} />}
+      {isSignupOpen && <SignupModal setIsOpenLoginModal={setIsSignupOpen} closeLink="stay" />}
       {toastComponents}
     </div>
   );

--- a/apps/client/src/context/AuthGlobalContext.tsx
+++ b/apps/client/src/context/AuthGlobalContext.tsx
@@ -1,10 +1,16 @@
-import { createContext, type ReactNode, useContext, useEffect } from 'react';
+import { createContext, type ReactNode, useCallback, useContext, useEffect, useState } from 'react';
 import { LOGGED_IN_USER_TIME_OUT_DAYS } from '@/constants/user-constants';
 import useUser, { type UseUserResult } from '@/hooks/use-user';
 import { logResponse } from '@/utils/log';
 import { timeDifference } from '@/utils/utils';
 
-type AuthGlobalContextValue = Omit<UseUserResult, 'setIsCurrentUserReady'>;
+type AuthGlobalContextValue = Omit<UseUserResult, 'setIsCurrentUserReady'> & {
+  /** Whether the app-level "please sign up" prompt overlay is open. */
+  isSignupPromptOpen: boolean;
+  setIsSignupPromptOpen: (open: boolean) => void;
+  /** Open the app-level signup prompt (e.g. when a logged-out visitor tries to vote). */
+  openSignupPrompt: () => void;
+};
 
 const AuthGlobalContext = createContext<AuthGlobalContextValue | null>(null);
 
@@ -24,6 +30,10 @@ const AuthGlobalContextProvider = ({ children }: { children: ReactNode }): React
     loginChild,
     switchToParent,
   } = useUser();
+
+  // App-level signup prompt, so it can be opened from anywhere (incl. inside another modal).
+  const [isSignupPromptOpen, setIsSignupPromptOpen] = useState(false);
+  const openSignupPrompt = useCallback(() => setIsSignupPromptOpen(true), []);
 
   useEffect(() => {
     // Check whether a user logged in and the time-out window has not passed
@@ -60,6 +70,9 @@ const AuthGlobalContextProvider = ({ children }: { children: ReactNode }): React
         createChild,
         loginChild,
         switchToParent,
+        isSignupPromptOpen,
+        setIsSignupPromptOpen,
+        openSignupPrompt,
       }}
     >
       {children}

--- a/apps/client/src/hooks/use-form.ts
+++ b/apps/client/src/hooks/use-form.ts
@@ -110,7 +110,8 @@ const useForm = (): UseFormResult => {
       return;
     }
 
-    const res = await logIn({ email, password, parentId });
+    // `parentId` is the route param value, which now carries a parent invite token.
+    const res = await logIn({ email, password, inviteToken: parentId });
     if (res.error) {
       // Check for email confirmation error
       if (res.error.message && res.error.message.includes('confirm your email')) {
@@ -135,7 +136,8 @@ const useForm = (): UseFormResult => {
       return;
     }
 
-    const res = await signUp({ name, email, password, role, parentId });
+    // `parentId` is the route param value, which now carries a parent invite token.
+    const res = await signUp({ name, email, password, role, inviteToken: parentId });
     if (res.error) {
       setErrors([res.error.message]);
       return;

--- a/apps/client/src/hooks/use-user.ts
+++ b/apps/client/src/hooks/use-user.ts
@@ -56,9 +56,9 @@ const useUser = (): UseUserResult => {
     return res;
   }, [applySession]);
 
-  const logIn = async ({ email, password, parentId }: LoginDto): Promise<ApiResult<User>> => {
+  const logIn = async ({ email, password, inviteToken }: LoginDto): Promise<ApiResult<User>> => {
     setIsCurrentUserReady(false);
-    const res = await apiAuth.login({ email, password, parentId });
+    const res = await apiAuth.login({ email, password, inviteToken });
     logResponse('🚪 Logging in', res);
     if (!res?.success) {
       setIsCurrentUserReady(true);
@@ -69,9 +69,9 @@ const useUser = (): UseUserResult => {
     return res;
   };
 
-  const signUp = async ({ email, password, name, role, parentId }: SignupDto): Promise<ApiResult<User>> => {
+  const signUp = async ({ email, password, name, role, inviteToken }: SignupDto): Promise<ApiResult<User>> => {
     setIsCurrentUserReady(false);
-    const res = await apiAuth.signup({ email, password, name, role, parentId });
+    const res = await apiAuth.signup({ email, password, name, role, inviteToken });
     logResponse('🎊 Signing up', res);
     if (!res?.success) {
       setIsCurrentUserReady(true);

--- a/apps/client/src/pages/Family.tsx
+++ b/apps/client/src/pages/Family.tsx
@@ -1,5 +1,5 @@
 import { type FormEvent, useEffect, useMemo, useState } from 'react';
-import { Link, Outlet, useMatchRoute, useNavigate } from '@tanstack/react-router';
+import { Outlet, useMatchRoute, useNavigate } from '@tanstack/react-router';
 import Loading from '@/components/Loading';
 import Modal from '@/components/Modal/Modal';
 import UserCard from '@/components/UserCard';
@@ -35,6 +35,8 @@ const Family = (): React.JSX.Element | null => {
   const [loginChildId, setLoginChildId] = useState<string | null>(null);
   const [resendChildId, setResendChildId] = useState<string | null>(null);
   const [isSwitchingParent, setIsSwitchingParent] = useState(false);
+  const [inviteUrl, setInviteUrl] = useState<string | null>(null);
+  const [isGeneratingInvite, setIsGeneratingInvite] = useState(false);
 
   useEffect(() => {
     if (isCurrentUserReady && !currentUser.id) {
@@ -53,7 +55,6 @@ const Family = (): React.JSX.Element | null => {
 
   const isParentSession = Boolean(currentUser.roles?.includes('parent')) && !actingAsChild;
   const activeChildId = actingAsChild ? currentUser.id : null;
-  const familyOwner = isParentSession ? currentUser : parentUser || currentUser;
   const children = useMemo<User[]>(() => {
     if (isParentSession) {
       return currentUser.children || [];
@@ -67,10 +68,58 @@ const Family = (): React.JSX.Element | null => {
         ? `${globalThis.location.protocol}//${globalThis.location.host}`
         : ''
       : globalThis.location.origin;
-  const ownerId = familyOwner?.id;
-  const shareLink = ownerId
-    ? `https://wa.me/?text=Hey%20kids%2C%20join%20me%20at%20SandwiCheck%20and%20be%20a%20part%20of%20my%20sandwich%20squad%21+${signupOrigin}${ROUTE_PATHS.SIGNUP_PARENT.replace('$parentId', ownerId)}`
-    : '';
+  const buildWhatsAppShare = (url: string): string =>
+    `https://wa.me/?text=Hey%20kids%2C%20join%20me%20at%20SandwiCheck%20and%20be%20a%20part%20of%20my%20sandwich%20squad%21+${url}`;
+
+  /*
+   * Mint a FRESH single-use invite link, replacing any previously generated one.
+   * Each link onboards exactly one child and is consumed on first redemption, so we
+   * deliberately do NOT reuse a token across children — generating again rotates the
+   * server-side token. Copy/Send act on the link shown after generating.
+   */
+  const handleGenerateInvite = async (): Promise<void> => {
+    setIsGeneratingInvite(true);
+    const res = await apiAuth.createInvite();
+    setIsGeneratingInvite(false);
+    if (!res?.success || !res.data?.token) {
+      showToast(res?.error?.message || 'Unable to generate an invite link right now.');
+      return;
+    }
+    setInviteUrl(`${signupOrigin}${ROUTE_PATHS.SIGNUP_PARENT.replace('$parentId', res.data.token)}`);
+  };
+
+  const handleCopyInvite = async (): Promise<void> => {
+    if (!inviteUrl) return;
+    const shareText = buildWhatsAppShare(inviteUrl);
+    try {
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(shareText);
+        showToast('Invite link copied to clipboard!');
+      } else {
+        // Fallback for older browsers
+        const textArea = document.createElement('textarea');
+        textArea.value = shareText;
+        textArea.style.position = 'fixed';
+        textArea.style.opacity = '0';
+        document.body.append(textArea);
+        textArea.select();
+        try {
+          document.execCommand('copy');
+          showToast('Invite link copied to clipboard!');
+        } catch {
+          showToast('Failed to copy link. Please copy manually.');
+        }
+        textArea.remove();
+      }
+    } catch {
+      showToast('Failed to copy link. Please copy manually.');
+    }
+  };
+
+  const handleSendInvite = (): void => {
+    if (!inviteUrl) return;
+    globalThis.open(buildWhatsAppShare(inviteUrl), '_blank', 'noopener,noreferrer');
+  };
 
   const resetActionStates = (): void => {
     setConvertChildId(null);
@@ -232,48 +281,39 @@ const Family = (): React.JSX.Element | null => {
                 Add child
               </button>
 
-              {shareLink && (
+              <button
+                type="button"
+                className="box-shadow-10 xl:box-shadow-20 inline-flex appearance-none items-center justify-center rounded-lg bg-magenta px-4 py-2 text-xs font-bold text-white uppercase transition-transform duration-200 hover:scale-105 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 md:px-5 md:py-3 md:text-sm"
+                onClick={handleGenerateInvite}
+                disabled={isGeneratingInvite}
+              >
+                <i className="icon icon-select-arrows mr-2 h-4 w-4 md:h-5 md:w-5"></i>
+                {inviteUrl ? 'New invite link' : 'Generate invite link'}
+              </button>
+
+              {inviteUrl && (
                 <>
                   <button
                     type="button"
-                    className="box-shadow-10 xl:box-shadow-20 inline-flex appearance-none items-center justify-center rounded-lg bg-magenta px-4 py-2 text-xs font-bold text-white uppercase transition-transform duration-200 hover:scale-105 focus:outline-none md:px-5 md:py-3 md:text-sm"
-                    onClick={async () => {
-                      try {
-                        if (navigator.clipboard && navigator.clipboard.writeText) {
-                          await navigator.clipboard.writeText(shareLink);
-                          showToast('Invite link copied to clipboard!');
-                        } else {
-                          // Fallback for older browsers
-                          const textArea = document.createElement('textarea');
-                          textArea.value = shareLink;
-                          textArea.style.position = 'fixed';
-                          textArea.style.opacity = '0';
-                          document.body.append(textArea);
-                          textArea.select();
-                          try {
-                            document.execCommand('copy');
-                            showToast('Invite link copied to clipboard!');
-                          } catch {
-                            showToast('Failed to copy link. Please copy manually.');
-                          }
-                          textArea.remove();
-                        }
-                      } catch {
-                        showToast('Failed to copy link. Please copy manually.');
-                      }
-                    }}
+                    className="box-shadow-10 xl:box-shadow-20 inline-flex appearance-none items-center justify-center rounded-lg bg-magenta px-4 py-2 text-xs font-bold text-white uppercase transition-transform duration-200 hover:scale-105 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 md:px-5 md:py-3 md:text-sm"
+                    onClick={handleCopyInvite}
+                    disabled={isGeneratingInvite}
                   >
                     <i className="icon icon-select-arrows mr-2 h-4 w-4 md:h-5 md:w-5"></i>
-                    Copy invite link
+                    Copy link
                   </button>
-                  <Link
-                    className="box-shadow-10 xl:box-shadow-20 inline-flex appearance-none items-center gap-2 rounded-lg bg-magenta px-4 py-2 text-xs font-bold text-white uppercase transition-transform duration-200 hover:scale-105 focus:outline-none md:px-5 md:py-3 md:text-sm"
-                    to={shareLink}
-                    target="_blank"
+                  <button
+                    type="button"
+                    className="box-shadow-10 xl:box-shadow-20 inline-flex appearance-none items-center gap-2 rounded-lg bg-magenta px-4 py-2 text-xs font-bold text-white uppercase transition-transform duration-200 hover:scale-105 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 md:px-5 md:py-3 md:text-sm"
+                    onClick={handleSendInvite}
+                    disabled={isGeneratingInvite}
                   >
-                    <span>Send invite link</span>
+                    <span>Send link</span>
                     <i className="icon icon-whatsapp h-5 w-5 md:h-6 md:w-6"></i>
-                  </Link>
+                  </button>
+                  <p className="w-full text-xs font-semibold opacity-80">
+                    Each link invites one child. Generating a new link replaces the previous one.
+                  </p>
                 </>
               )}
             </div>

--- a/apps/client/src/routes/__root.tsx
+++ b/apps/client/src/routes/__root.tsx
@@ -2,15 +2,27 @@ import { createRootRoute, Outlet } from '@tanstack/react-router';
 import { TanStackRouterDevtools } from '@tanstack/react-router-devtools';
 import Footer from '@/components/Footer/Footer';
 import Header from '@/components/Header/Header';
+import SignupModal from '@/components/Signup/SignupModal';
+import { ROUTE_PATHS } from '@/constants/route-paths';
+import { useAuthGlobalContext } from '@/context/AuthGlobalContext';
 import Error404 from '@/pages/Error404';
 
 const RootComponent = (): React.JSX.Element => {
+  const { isSignupPromptOpen, setIsSignupPromptOpen } = useAuthGlobalContext();
+
   return (
     <>
       <Header />
       <Outlet />
       <Footer />
       <div id="modal-root"></div>
+      {/*
+       * App-level signup prompt: a sibling of the route Outlet (not nested in any route
+       * modal), so it survives even when opened from inside the sandwich detail modal — the
+       * one-active-modal ModalContext closes that modal while this overlay stays mounted.
+       * Closing returns to the gallery (avoids a dead-end on the header-less /sandwich route).
+       */}
+      {isSignupPromptOpen && <SignupModal setIsOpenLoginModal={setIsSignupPromptOpen} closeLink={ROUTE_PATHS.LATEST} />}
       {import.meta.env.DEV && <TanStackRouterDevtools />}
     </>
   );

--- a/apps/client/src/services/api-auth.ts
+++ b/apps/client/src/services/api-auth.ts
@@ -1,6 +1,7 @@
 import type {
   ChangePasswordDto,
   CreateChildDto,
+  CreateInviteData,
   ForgotPasswordDto,
   LoginChildDto,
   LoginDto,
@@ -26,18 +27,23 @@ const api = createFetchApi(`${import.meta.env.VITE_API_SERVER}/api/v1/auth`, {
  * Base URL: /api/v1/auth
  */
 
-/** POST /signup — register a new user. */
-export const signup = async ({ email, password, name, role, parentId }: SignupDto): Promise<ApiResult<User>> => {
+/** POST /signup — register a new user (optionally under a parent invite token). */
+export const signup = async ({ email, password, name, role, inviteToken }: SignupDto): Promise<ApiResult<User>> => {
   return await handleResponse<User>(async () => {
-    return api.post('/signup', { email, password, name, role, parentId });
+    return api.post('/signup', { email, password, name, role, inviteToken });
   });
 };
 
-/** POST /login — log in with email/password (optionally under a parent). */
-export const login = async ({ email, password, parentId }: LoginDto): Promise<ApiResult<User>> => {
+/** POST /login — log in with email/password (optionally under a parent invite token). */
+export const login = async ({ email, password, inviteToken }: LoginDto): Promise<ApiResult<User>> => {
   return await handleResponse<User>(async () => {
-    return api.post('/login', { email, password, parentId });
+    return api.post('/login', { email, password, inviteToken });
   });
+};
+
+/** POST /create-invite — issue a parent invite token (parent only). */
+export const createInvite = async (): Promise<ApiResult<CreateInviteData>> => {
+  return await handleResponse<CreateInviteData>(async () => api.post('/create-invite'));
 };
 
 /** GET /session — active authenticated session details. */

--- a/apps/client/src/services/api-sandwiches.ts
+++ b/apps/client/src/services/api-sandwiches.ts
@@ -45,14 +45,9 @@ export const createSandwich = async (parameters: BuilderSandwich): Promise<ApiRe
   return await handleResponse<Sandwich>(async () => api.post('/', payload));
 };
 
-/** POST /:sandwichId/vote — add a vote (private). */
+/** POST /:sandwichId/vote — cast a vote (private; also adds the sandwich to the caller's favorites, idempotent). */
 export const addVoteToSandwich = async (sandwichId: string): Promise<ApiResult<Sandwich>> => {
   return await handleResponse<Sandwich>(async () => api.post(`/${sandwichId}/vote`));
-};
-
-/** DELETE /:sandwichId/vote — remove a vote (private). */
-export const removeVoteFromSandwich = async (sandwichId: string): Promise<ApiResult<Sandwich>> => {
-  return await handleResponse<Sandwich>(async () => api.delete(`/${sandwichId}/vote`));
 };
 
 /** PUT /:sandwichId — update a sandwich (private, owner). */

--- a/apps/client/src/services/api-users.ts
+++ b/apps/client/src/services/api-users.ts
@@ -3,7 +3,6 @@ import type { ApiResult } from '@/types/api';
 import type { DayMenuItem, User } from '@/types/domain';
 import { handleResponse } from '@/utils/api-utils';
 import { createFetchApi } from '@/utils/fetch-api';
-import { log } from '@/utils/log';
 
 const api = createFetchApi(`${import.meta.env.VITE_API_SERVER}/api/v1/users`, {
   'Access-Control-Allow-Origin': import.meta.env.VITE_HOST,
@@ -18,7 +17,8 @@ interface UpdateUserParams extends UpdateUserDto {
  * Users API Service
  *
  * Implements all user management endpoints from the server API: profiles,
- * favorites, week menus, and user relationships.
+ * week menus, and user relationships. (Favoriting is owned by the vote endpoint
+ * in api-sandwiches.ts — voting a sandwich adds it to the user's favorites.)
  *
  * Base URL: /api/v1/users
  */
@@ -59,49 +59,6 @@ export const updateUserById = async (
   if (file && file.imageBuffer) formData.append('file', file.imageBuffer, 'profile-picture.png');
 
   return await handleResponse<User>(async () => api.put(`/${userId}`, formData));
-};
-
-/** POST /:userId/favorite-sandwiches/:sandwichId — favorite a sandwich (private). */
-export const addSandwichToFavoritesByUserId = async ({
-  userId,
-  sandwichId,
-}: {
-  userId: string;
-  sandwichId: string;
-}): Promise<ApiResult<string[]>> => {
-  return await handleResponse<string[]>(async () => api.post(`/${userId}/favorite-sandwiches/${sandwichId}`));
-};
-
-/** DELETE /:userId/favorite-sandwiches/:sandwichId — unfavorite a sandwich (private). */
-export const removeSandwichFromFavoritesByUserId = async ({
-  userId,
-  sandwichId,
-}: {
-  userId: string;
-  sandwichId: string;
-}): Promise<ApiResult<string[]>> => {
-  return await handleResponse<string[]>(async () => api.delete(`/${userId}/favorite-sandwiches/${sandwichId}`));
-};
-
-/** Record a local vote for a sandwich (for logged-out users). */
-export const addSandwichToFavoritesInLocalStorage = (sandwichId: string): void => {
-  const allVotesString = localStorage.getItem('user_votes');
-  const allVotes: string[] = allVotesString ? JSON.parse(allVotesString) : [];
-  allVotes.push(sandwichId);
-  localStorage.setItem('user_votes', JSON.stringify([...new Set(allVotes)]));
-};
-
-/** Check whether a sandwich was voted for locally (for logged-out users). */
-export const hasUserVotedForSandwichByIdUsingLocalStorage = (sandwichId: string): boolean => {
-  const allVotesString = localStorage.getItem('user_votes');
-  if (!allVotesString) return false;
-
-  const allVotes = JSON.parse(allVotesString) as string[] | null;
-  if (allVotes && allVotes.includes(sandwichId)) {
-    log('User already voted locally');
-    return true;
-  }
-  return false;
 };
 
 /** GET / — all users (admin only). */

--- a/apps/client/src/services/votes.ts
+++ b/apps/client/src/services/votes.ts
@@ -1,27 +1,20 @@
 import type { ApiResult } from '@/types/api';
 import type { CurrentUser, Sandwich } from '@/types/domain';
 import { addVoteToSandwich } from './api-sandwiches.ts';
-import { addSandwichToFavoritesByUserId, hasUserVotedForSandwichByIdUsingLocalStorage } from './api-users.ts';
 
 export const hasUserVotedForSandwich = (sandwich: Sandwich, user: CurrentUser): boolean => {
-  if (!user.id) return hasUserVotedForSandwichByIdUsingLocalStorage(sandwich.id);
+  // Voting requires an account; a logged-out visitor has never voted.
+  if (!user.id) return false;
 
+  // A vote adds the sandwich to the user's favorites, so a favorited sandwich is a voted one.
   return user.favoriteSandwiches?.includes(sandwich.id) ?? false;
 };
 
-export const voteForSandwich = async ({
-  userId,
-  sandwichId,
-}: {
-  userId?: string;
-  sandwichId: string;
-}): Promise<ApiResult<Sandwich>> => {
-  if (userId) {
-    const favoritesResponse = await addSandwichToFavoritesByUserId({ userId, sandwichId });
-    if (!favoritesResponse?.success) {
-      return favoritesResponse as ApiResult<Sandwich>;
-    }
-  }
-
+export const voteForSandwich = async ({ sandwichId }: { sandwichId: string }): Promise<ApiResult<Sandwich>> => {
+  /*
+   * Casts an authenticated vote. The server couples voting to favorites: a single
+   * call increments the sandwich's votesCount and adds it to the caller's favorites
+   * (idempotent per user). Logged-out visitors are routed to signup by the caller.
+   */
   return await addVoteToSandwich(sandwichId);
 };

--- a/apps/server/config/.env.example
+++ b/apps/server/config/.env.example
@@ -4,6 +4,11 @@ PORT=5001
 CLIENT_URL=https://sandwicheck.app
 # === database
 MONGO_URI=
+# Optional. Selects the database explicitly (overrides the /<db> path in MONGO_URI).
+# If unset AND MONGO_URI has no /<db> path, the MongoDB driver falls back to its
+# built-in default database, "test". Set this (or add /<db> to MONGO_URI) in
+# production to avoid writing to "test". Local dev URIs already include /sandwicheck.
+# MONGO_DB_NAME=sandwicheck
 # === file uploads
 MAX_UPLOAD_SIZE_IN_BYTES=10485760 # 10MB
 USER_IMAGE_WIDTH=480
@@ -18,6 +23,13 @@ JWT_EXPIRES_IN=90d
 JWT_COOKIE_EXPIRE_IN_DAYS=90
 BCRYPT_SALT_ROUNDS=10
 RESET_PASSWORD_EXPIRES_IN=1200000 # 20 minutes
+INVITE_TOKEN_EXPIRES_IN=604800000 # 7 days in milliseconds; parent invite link lifetime
+# Optional. Global pepper mixed into the SHA-256 hashing of reset-password,
+# email-confirmation, and parent-invite tokens (defense-in-depth: a leaked DB alone
+# can't be matched against tokens). Use a DEDICATED secret, separate from JWT_SECRET,
+# so the two rotate independently. Unset = no-op (backward compatible). Setting or
+# changing it invalidates any unredeemed tokens; does NOT affect passwords (bcrypt).
+# TOKEN_HASH_PEPPER=
 # === mail
 # For LOCAL DEVELOPMENT with Mailpit:
 # - Start Mailpit: docker-compose up -d mailpit
@@ -45,3 +57,7 @@ EMAIL_CONFIRMATION_RESEND_COOLDOWN_MS=900000  # 15 minutes in milliseconds
 # === logging (optional; safe defaults shown)
 # LOG_LEVEL=info          # set to 'debug' to also log every HTTP request
 # LOG_STACK_TRACES=false  # 'true' to log error stack traces (never sent in API responses)
+
+# === scripts (optional CLI flags for one-off service scripts; unset = false)
+# DRY_RUN=false  # generate-missing-sandwich-images: report only, write nothing
+# FORCE=false    # generate-missing-sandwich-images: regenerate even if the image exists

--- a/apps/server/config/db.ts
+++ b/apps/server/config/db.ts
@@ -8,6 +8,14 @@ const connectDB = async (): Promise<void> => {
     }
 
     const conn = await mongoose.connect(process.env.MONGO_URI, {
+      /*
+       * Honor MONGO_DB_NAME when set; otherwise fall back to the database in the
+       * URI path. We deliberately do NOT hardcode a default here: a hardcoded name
+       * would silently switch the live database the moment this code deploys. The
+       * cutover away from Mongoose's implicit "test" default must be a conscious
+       * ops action (set MONGO_DB_NAME or add a /<db> path to MONGO_URI).
+       */
+      dbName: process.env.MONGO_DB_NAME || undefined,
       serverSelectionTimeoutMS: 5000, // 5 seconds - fail fast if MongoDB is not available
       connectTimeoutMS: 5000, // 5 seconds - timeout for initial connection
     });
@@ -17,6 +25,13 @@ const connectDB = async (): Promise<void> => {
       database: conn.connection.name,
       // Explicitly do NOT log: conn.connection.uri or MONGO_URI
     });
+
+    // Guard against the implicit "test" database in production (misconfigured URI)
+    if (conn.connection.name === 'test' && process.env.NODE_ENV === 'production') {
+      logger.warn(
+        'MongoDB is using the default "test" database in production — set MONGO_DB_NAME or add a /<database> path to MONGO_URI',
+      );
+    }
   } catch (error) {
     // SECURITY: Error may contain connection string - sanitize it
     const err = error as Error;

--- a/apps/server/constants/__test__/mailing.test.ts
+++ b/apps/server/constants/__test__/mailing.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { generateChildActivationHtml, generateEmailConfirmationHtml, generateHtmlMessage } from '../mailing.ts';
+
+const XSS = '<img src=x onerror=alert(1)>';
+
+describe('email template HTML escaping', () => {
+  it('escapes user.name in the password-reset email', () => {
+    const html = generateHtmlMessage({ user: { name: XSS }, resetURL: 'https://app/reset/abc' });
+    expect(html).not.toContain('<img src=x');
+    expect(html).toContain('&lt;img src=x onerror=alert(1)&gt;');
+  });
+
+  it('escapes user.name in the confirmation email', () => {
+    const html = generateEmailConfirmationHtml({ user: { name: XSS }, confirmationURL: 'https://app/c/abc' });
+    expect(html).not.toContain('<img src=x');
+    expect(html).toContain('&lt;img');
+  });
+
+  it('escapes childName and parentName in the child-activation email', () => {
+    const html = generateChildActivationHtml({
+      childName: XSS,
+      parentName: '<b>evil</b>',
+      confirmationURL: 'https://app/c/abc',
+      resetURL: 'https://app/reset/abc',
+    });
+    expect(html).not.toContain('<img src=x');
+    expect(html).not.toContain('<b>evil</b>');
+    expect(html).toContain('&lt;img');
+    expect(html).toContain('&lt;b&gt;evil&lt;/b&gt;');
+  });
+
+  it('leaves the legitimate URL untouched', () => {
+    const url = 'https://app/reset/abc-123';
+    const html = generateHtmlMessage({ user: { name: 'Alice' }, resetURL: url });
+    expect(html).toContain(`href="${url}"`);
+  });
+});

--- a/apps/server/constants/mailing.ts
+++ b/apps/server/constants/mailing.ts
@@ -2,11 +2,25 @@ interface MailUser {
   name?: string;
 }
 
+/**
+ * Escape user-controlled text before interpolating it into HTML email bodies.
+ * Names are attacker-controlled at signup, so without this a name like
+ * `<img src=x onerror=...>` would be injected into the email markup. The `&`
+ * replacement must run first. Plain-text email bodies do not need this.
+ */
+const escapeHtml = (value?: string): string =>
+  (value ?? '')
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+
 export const generateHtmlMessage = ({ user, resetURL }: { user: MailUser; resetURL: string }): string => {
   return `
     <div style="font-family: Arial, sans-serif; font-size: 16px; color: #333;">
         <h2>Password Reset Request</h2>
-        <p>Hello ${user.name},<br />We received a request to reset your password. Please click the link below to reset your password:</p>
+        <p>Hello ${escapeHtml(user.name)},<br />We received a request to reset your password. Please click the link below to reset your password:</p>
         <p><a href="${resetURL}" style="color: #4a90e2; text-decoration: none;">${resetURL}</a></p>
         <p>If you did not request this password reset, please ignore this email.</p>
     </div>`;
@@ -32,7 +46,7 @@ export const generateEmailConfirmationHtml = ({
   return `
     <div style="font-family: Arial, sans-serif; font-size: 16px; color: #333;">
         <h2>Email Confirmation</h2>
-        <p>Hello ${user.name},<br />Thank you for signing up! Please confirm your email address by clicking the link below:</p>
+        <p>Hello ${escapeHtml(user.name)},<br />Thank you for signing up! Please confirm your email address by clicking the link below:</p>
         <p><a href="${confirmationURL}" style="color: #4a90e2; text-decoration: none;">${confirmationURL}</a></p>
         <p>If you did not create an account, please ignore this email.</p>
     </div>`;
@@ -65,13 +79,14 @@ export const generateChildActivationHtml = ({
   confirmationURL: string;
   resetURL: string;
 }): string => {
-  const inviterName = parentName || 'Your parent';
-  const inviterReference = parentName || 'your parent';
+  const safeParentName = parentName ? escapeHtml(parentName) : undefined;
+  const inviterName = safeParentName || 'Your parent';
+  const inviterReference = safeParentName || 'your parent';
 
   return `
     <div style="font-family: Arial, sans-serif; font-size: 16px; color: #333;">
         <h2>Welcome to SandwiCheck!</h2>
-        <p>Hi ${childName},</p>
+        <p>Hi ${escapeHtml(childName)},</p>
         <p>${inviterName} has created a SandwiCheck account for you so you can plan your perfect sandwiches together.</p>
         <p style="margin-top: 24px;"><strong>Step 1: Confirm your email</strong></p>
         <p><a href="${confirmationURL}" style="color: #e6127d; text-decoration: none;">Confirm my email address</a></p>

--- a/apps/server/controllers/authChildController.ts
+++ b/apps/server/controllers/authChildController.ts
@@ -147,3 +147,34 @@ export const getSession = asyncHandler(async (request, res, next) => {
     },
   });
 });
+
+/*
+ * @desc    Create a parent invite token used to link children on signup/login
+ * @route   POST /api/auth/create-invite
+ * @access  Private/Parent
+ *
+ * Replaces the previous flow where any raw parentId in the request body linked a
+ * caller to an arbitrary user without consent. Only the (hashed) token is stored;
+ * the raw token is returned once so the parent can share an invite link. The token
+ * is single-use: it is consumed the first time a child redeems it, and a new call
+ * replaces any previous unused token — so only the most recently generated link is
+ * live (one link onboards one child).
+ */
+export const createInvite = asyncHandler(async (request, res, _next) => {
+  const parentUser = request.user!;
+
+  const rawToken = hashAndTokens.generateResetPasswordToken();
+  const expiresInMs = Number.parseInt(process.env.INVITE_TOKEN_EXPIRES_IN || '604800000', 10); // default 7 days
+
+  await User.findByIdAndUpdate(parentUser._id, {
+    $set: {
+      inviteToken: hashAndTokens.hashToken(rawToken),
+      inviteTokenExpire: new Date(Date.now() + expiresInMs),
+    },
+  });
+
+  res.status(200).json({
+    success: true,
+    data: { token: rawToken },
+  });
+});

--- a/apps/server/controllers/authController.ts
+++ b/apps/server/controllers/authController.ts
@@ -376,8 +376,12 @@ export const resetPassword = asyncHandler<ParamsDictionary, unknown, ResetPasswo
     return next(createHttpError.BadRequest('A new password is required'));
   }
 
-  // Enforce the same length policy as signup and change-password.
-  if (newPassword.length < 5 || newPassword.length > 30) {
+  /*
+   * Enforce the same length policy as signup and change-password. The typeof guard
+   * matters because the body is untrusted JSON: a non-string value (e.g. a number)
+   * has an undefined `.length`, so the bounds check below would silently pass.
+   */
+  if (typeof newPassword !== 'string' || newPassword.length < 5 || newPassword.length > 30) {
     return next(createHttpError.BadRequest('A password must contain between 5 and 30 characters'));
   }
 

--- a/apps/server/controllers/authController.ts
+++ b/apps/server/controllers/authController.ts
@@ -19,7 +19,7 @@ import {
   generateHtmlMessage,
   generateTextMessage,
 } from '#constants/mailing.ts';
-import User from '#models/UserModel.ts';
+import User, { type UserDocument } from '#models/UserModel.ts';
 import asyncHandler from '#utils/asyncHandler.ts';
 import { removeCookie, setTokenCookie } from '#utils/cookies.ts';
 import delay from '#utils/delay.ts';
@@ -27,6 +27,28 @@ import * as hashAndTokens from '#utils/hashAndTokens.ts';
 import logger from '#utils/logger.ts';
 import sendEmail from '#utils/mailer.ts';
 import { createUserParentsConnections } from '#utils/manageUserConnections.ts';
+
+/**
+ * Link a freshly authenticated user to the parent that issued a still-valid invite
+ * token, atomically consuming the token so it is single-use: the matching parent is
+ * found and its token cleared in one operation, so a link cannot be redeemed twice
+ * (and a concurrent double-redeem resolves to a single winner). Returns true when a
+ * link is made. Best-effort by design: callers do not fail the primary action
+ * (signup/login) on a missing/expired/already-used token — the account is still
+ * created/logged in and the parent can issue a new invite.
+ */
+const linkParentByInviteToken = async (user: UserDocument, rawToken: string): Promise<boolean> => {
+  const inviteToken = hashAndTokens.hashToken(rawToken);
+  const parent = await User.findOneAndUpdate(
+    { inviteToken, inviteTokenExpire: { $gt: Date.now() } },
+    { $unset: { inviteToken: 1, inviteTokenExpire: 1 } },
+  );
+  if (!parent) {
+    return false;
+  }
+  await createUserParentsConnections(user, parent._id);
+  return true;
+};
 
 /*
  * @desc    Signup
@@ -39,7 +61,7 @@ export const signup = asyncHandler<ParamsDictionary, unknown, SignupDto>(async (
   const email = req.body.email?.trim().toLowerCase();
   const password = req.body.password;
   const role = req.body.role?.trim();
-  const parentId = req.body.parentId?.trim();
+  const inviteToken = req.body.inviteToken?.trim();
 
   if (!name || !email || !password || !role) {
     return next(createHttpError.BadRequest('All fields are required'));
@@ -72,7 +94,7 @@ export const signup = asyncHandler<ParamsDictionary, unknown, SignupDto>(async (
     userExists.emailConfirmationResendCount = 0; // Reset resend count on new signup attempt
     userExists.emailConfirmationResendCooldown = undefined; // Reset cooldown on new signup attempt
     userExists.name = name;
-    userExists.password = await bcrypt.hash(password, Number.parseInt(process.env.BCRYPT_SALT_ROUNDS ?? '', 10));
+    userExists.password = await bcrypt.hash(password, Number.parseInt(process.env.BCRYPT_SALT_ROUNDS || '10', 10));
     userExists.roles = [ROLE.user, role];
 
     await userExists.save();
@@ -110,7 +132,7 @@ export const signup = asyncHandler<ParamsDictionary, unknown, SignupDto>(async (
     }
   }
 
-  const passwordHash = await bcrypt.hash(password, Number.parseInt(process.env.BCRYPT_SALT_ROUNDS ?? '', 10));
+  const passwordHash = await bcrypt.hash(password, Number.parseInt(process.env.BCRYPT_SALT_ROUNDS || '10', 10));
 
   const user = await User.create({
     name,
@@ -124,10 +146,13 @@ export const signup = asyncHandler<ParamsDictionary, unknown, SignupDto>(async (
     return next(createHttpError.BadRequest('Invalid user data'));
   }
 
-  if (parentId) {
-    const res: unknown = await createUserParentsConnections(user, parentId);
-    if (!res) {
-      return next(new createHttpError.BadRequest('Parent not found'));
+  if (inviteToken) {
+    const linked = await linkParentByInviteToken(user, inviteToken);
+    if (!linked) {
+      logger.warn('Signup used an invalid or expired invite token', {
+        requestId: req.requestId,
+        userId: user._id.toString(),
+      });
     }
   }
 
@@ -203,7 +228,7 @@ export const login = asyncHandler<ParamsDictionary, unknown, LoginDto>(async (re
   // Sanitize and trim inputs
   const email = req.body.email?.trim().toLowerCase();
   const password = req.body.password;
-  const parentId = req.body.parentId?.trim();
+  const inviteToken = req.body.inviteToken?.trim();
 
   if (!email || !password) {
     return next(new createHttpError.BadRequest('Please provide an email and password'));
@@ -222,10 +247,13 @@ export const login = asyncHandler<ParamsDictionary, unknown, LoginDto>(async (re
     return next(createHttpError.Unauthorized('Please confirm your email before logging in'));
   }
 
-  if (parentId) {
-    const res: unknown = await createUserParentsConnections(user, parentId);
-    if (!res) {
-      return next(new createHttpError.BadRequest('Parent not found'));
+  if (inviteToken) {
+    const linked = await linkParentByInviteToken(user, inviteToken);
+    if (!linked) {
+      logger.warn('Login used an invalid or expired invite token', {
+        requestId: req.requestId,
+        userId: user._id.toString(),
+      });
     }
   }
 
@@ -276,7 +304,7 @@ export const changePassword = asyncHandler<ParamsDictionary, unknown, ChangePass
     return next(createHttpError.Unauthorized('Old password is incorrect'));
   }
 
-  user.password = await bcrypt.hash(newPassword, Number.parseInt(process.env.BCRYPT_SALT_ROUNDS ?? '', 10));
+  user.password = await bcrypt.hash(newPassword, Number.parseInt(process.env.BCRYPT_SALT_ROUNDS || '10', 10));
 
   await user.save();
 
@@ -348,6 +376,11 @@ export const resetPassword = asyncHandler<ParamsDictionary, unknown, ResetPasswo
     return next(createHttpError.BadRequest('A new password is required'));
   }
 
+  // Enforce the same length policy as signup and change-password.
+  if (newPassword.length < 5 || newPassword.length > 30) {
+    return next(createHttpError.BadRequest('A password must contain between 5 and 30 characters'));
+  }
+
   const resetPasswordToken = hashAndTokens.hashToken(String(req.params.resetToken));
 
   const user = await User.findOne({
@@ -360,7 +393,7 @@ export const resetPassword = asyncHandler<ParamsDictionary, unknown, ResetPasswo
   }
 
   // Hash the new password before saving
-  user.password = await bcrypt.hash(newPassword, Number.parseInt(process.env.BCRYPT_SALT_ROUNDS ?? '', 10));
+  user.password = await bcrypt.hash(newPassword, Number.parseInt(process.env.BCRYPT_SALT_ROUNDS || '10', 10));
   user.resetPasswordToken = undefined;
   user.resetPasswordExpire = undefined;
 

--- a/apps/server/controllers/ingredientsController.ts
+++ b/apps/server/controllers/ingredientsController.ts
@@ -12,7 +12,16 @@ import { removeAllIngredientImagesByImageBase, saveIngredientImages } from '#uti
  * @access  Public
  */
 export const getIngredients = asyncHandler(async (req, res, _next) => {
-  const { dietaryPreferences, type, sortBy } = { ...req.query, ...req.body };
+  const parameters = { ...req.query, ...req.body };
+  /*
+   * Coerce inputs to strings before using them. Without this, a value like
+   * ?type[$ne]= arrives as an object and would be injected as a Mongo operator,
+   * and dietaryPreferences.split() would throw on non-string input.
+   */
+  const dietaryPreferences =
+    typeof parameters.dietaryPreferences === 'string' ? parameters.dietaryPreferences : undefined;
+  const type = typeof parameters.type === 'string' ? parameters.type : undefined;
+  const sortBy = typeof parameters.sortBy === 'string' ? parameters.sortBy : undefined;
   const query: Record<string, unknown> = {};
 
   if (dietaryPreferences) {

--- a/apps/server/controllers/sandwichesController.ts
+++ b/apps/server/controllers/sandwichesController.ts
@@ -217,29 +217,40 @@ export const deleteSandwich = asyncHandler(async (req, res, next) => {
 });
 
 /*
- * @desc    Update vote count of a sandwich
- * @route   POST|DELETE /api/sandwiches/:sandwichId/vote
+ * @desc    Vote for a sandwich (also adds it to the voter's favorites)
+ * @route   POST /api/sandwiches/:sandwichId/vote
  * @access  Private
  */
-export const updateSandwichVotesCount = asyncHandler(async (req, res, next) => {
-  const { sandwichId } = req.params;
-  const method = req.method;
+export const voteForSandwich = asyncHandler(async (req, res, next) => {
+  const sandwichId = Array.isArray(req.params.sandwichId) ? req.params.sandwichId[0] : req.params.sandwichId;
 
-  const sandwich = await Sandwich.findById(sandwichId);
+  if (!sandwichId || !mongoose.Types.ObjectId.isValid(sandwichId)) {
+    return next(createHttpError.BadRequest('Invalid sandwich id'));
+  }
 
-  if (!sandwich) {
+  if (!(await Sandwich.exists({ _id: sandwichId }))) {
     return next(createHttpError.NotFound('Sandwich not found'));
   }
 
-  if (method === 'POST') {
-    sandwich.votesCount = (sandwich.votesCount ?? 0) + 1;
-  } else if (method === 'DELETE') {
-    sandwich.votesCount = Math.max(0, (sandwich.votesCount ?? 0) - 1);
-  } else {
-    throw createHttpError.MethodNotAllowed('Unsupported vote action');
-  }
+  /*
+   * Voting requires authentication and is coupled to favorites: a vote adds the
+   * sandwich to the caller's favoriteSandwiches and bumps the denormalized
+   * votesCount. The favoriteSandwiches set is the idempotency gate — the `$ne`
+   * filter means $addToSet only matches (and modifies) when the sandwich is not
+   * already favorited, so votesCount is incremented exactly once per user and
+   * re-voting is a harmless no-op. Two single-doc updates (no transaction) because
+   * the local MongoDB is standalone; the only failure mode is a missed +1, never
+   * an over-count.
+   */
+  const favoriteUpdate = await User.updateOne(
+    { _id: req.user!._id, favoriteSandwiches: { $ne: sandwichId } },
+    { $addToSet: { favoriteSandwiches: sandwichId } },
+  );
+  const counted = favoriteUpdate.modifiedCount === 1;
 
-  await sandwich.save();
+  const sandwich = counted
+    ? await Sandwich.findOneAndUpdate({ _id: sandwichId }, { $inc: { votesCount: 1 } }, { new: true })
+    : await Sandwich.findById(sandwichId);
 
   res.status(200).json({
     success: true,

--- a/apps/server/controllers/usersController.ts
+++ b/apps/server/controllers/usersController.ts
@@ -1,7 +1,6 @@
 import type { ParamsDictionary } from 'express-serve-static-core';
 import { ROLE, type UpdateUserDto } from '@sandwicheck/shared';
 import bcrypt from 'bcryptjs';
-import type { RequestHandler } from 'express';
 import createHttpError from 'http-errors';
 import type mongoose from 'mongoose';
 import { PROFILE_PICTURES_DIR } from '#config/dir.ts';
@@ -235,35 +234,3 @@ export const deleteUser = asyncHandler(async (req, res, next) => {
 
   res.status(200).json({ success: true, message: 'User deleted successfully' });
 });
-
-/*
- * @desc    Add / Remove favorite sandwich
- * @route   POST | DELETE /api/users/:userId/favorite-sandwiches/:sandwichId
- * @access  Private / User
- */
-export const updateFavoriteSandwiches: RequestHandler = async (req, res, next) => {
-  const userId = Array.isArray(req.params.userId) ? req.params.userId[0] : req.params.userId;
-  const sandwichId = Array.isArray(req.params.sandwichId) ? req.params.sandwichId[0] : req.params.sandwichId;
-
-  const user = await User.findById(userId);
-
-  if (!user) {
-    return next(createHttpError.NotFound('User not found'));
-  }
-
-  const favoriteSandwiches = user.favoriteSandwiches as mongoose.Types.Array<mongoose.Types.ObjectId>;
-  const isSandwichAlreadyFavorite = favoriteSandwiches.includes(sandwichId as unknown as mongoose.Types.ObjectId);
-
-  if (req.method === 'POST' && !isSandwichAlreadyFavorite) {
-    favoriteSandwiches.push(sandwichId);
-  } else if (req.method === 'DELETE' && isSandwichAlreadyFavorite) {
-    favoriteSandwiches.pull(sandwichId);
-  }
-
-  await user.save();
-
-  res.status(200).json({
-    success: true,
-    data: user.favoriteSandwiches,
-  });
-};

--- a/apps/server/middleware/__test__/authMiddleware.test.ts
+++ b/apps/server/middleware/__test__/authMiddleware.test.ts
@@ -1,0 +1,93 @@
+import { ROLE } from '@sandwicheck/shared';
+import type { Request, Response } from 'express';
+import mongoose from 'mongoose';
+import { describe, expect, it, vi } from 'vitest';
+import { authorize } from '../authMiddleware.ts';
+
+interface MockUser {
+  _id: mongoose.Types.ObjectId;
+  roles: string[];
+  sandwiches: mongoose.Types.ObjectId[];
+  children: mongoose.Types.ObjectId[];
+}
+
+const makeUser = (overrides: Partial<MockUser> = {}): MockUser => ({
+  _id: new mongoose.Types.ObjectId(),
+  roles: [ROLE.user],
+  sandwiches: [],
+  children: [],
+  ...overrides,
+});
+
+/** Invoke an authorize() middleware with a mock req and return the spied next(). */
+const invoke = async (
+  roles: Parameters<typeof authorize>,
+  user: MockUser,
+  params: Record<string, string>,
+): Promise<ReturnType<typeof vi.fn>> => {
+  const req = { user, params } as unknown as Request;
+  const res = {} as Response;
+  const next = vi.fn();
+  await authorize(...roles)(req, res, next);
+  return next;
+};
+
+const wasAllowed = (next: ReturnType<typeof vi.fn>): boolean =>
+  next.mock.calls.length === 1 && next.mock.calls[0]?.[0] === undefined;
+
+const forbiddenStatus = (next: ReturnType<typeof vi.fn>): number | undefined => next.mock.calls[0]?.[0]?.status;
+
+describe('authorize middleware', () => {
+  it('allows a user to edit their OWN favorites (userId + sandwichId, own profile)', async () => {
+    const user = makeUser();
+    const sandwichId = new mongoose.Types.ObjectId().toString();
+    const next = await invoke([ROLE.user], user, { userId: user._id.toString(), sandwichId });
+    expect(wasAllowed(next)).toBe(true);
+  });
+
+  it('BLOCKS editing another user’s favorites even when the actor owns the sandwich (IDOR regression)', async () => {
+    const ownedSandwich = new mongoose.Types.ObjectId();
+    const attacker = makeUser({ sandwiches: [ownedSandwich] });
+    const victimId = new mongoose.Types.ObjectId().toString();
+    const next = await invoke([ROLE.user], attacker, { userId: victimId, sandwichId: ownedSandwich.toString() });
+    expect(forbiddenStatus(next)).toBe(403);
+  });
+
+  it('allows the owner on a sandwich-scoped route (no userId)', async () => {
+    const ownedSandwich = new mongoose.Types.ObjectId();
+    const owner = makeUser({ sandwiches: [ownedSandwich] });
+    const next = await invoke([ROLE.user], owner, { sandwichId: ownedSandwich.toString() });
+    expect(wasAllowed(next)).toBe(true);
+  });
+
+  it('blocks a non-owner on a sandwich-scoped route', async () => {
+    const owner = makeUser({ sandwiches: [new mongoose.Types.ObjectId()] });
+    const next = await invoke([ROLE.user], owner, { sandwichId: new mongoose.Types.ObjectId().toString() });
+    expect(forbiddenStatus(next)).toBe(403);
+  });
+
+  it('lets an admin bypass all checks', async () => {
+    const admin = makeUser({ roles: [ROLE.user, ROLE.admin] });
+    const next = await invoke([ROLE.admin], admin, { userId: new mongoose.Types.ObjectId().toString() });
+    expect(wasAllowed(next)).toBe(true);
+  });
+
+  it('forbids a user lacking the required role', async () => {
+    const user = makeUser({ roles: [ROLE.user] });
+    const next = await invoke([ROLE.admin], user, {});
+    expect(forbiddenStatus(next)).toBe(403);
+  });
+
+  it('allows a parent to act on their own child', async () => {
+    const childId = new mongoose.Types.ObjectId();
+    const parent = makeUser({ roles: [ROLE.user, ROLE.parent], children: [childId] });
+    const next = await invoke([ROLE.user, ROLE.parent], parent, { userId: childId.toString() });
+    expect(wasAllowed(next)).toBe(true);
+  });
+
+  it('forbids a parent from acting on an unrelated user', async () => {
+    const parent = makeUser({ roles: [ROLE.user, ROLE.parent], children: [new mongoose.Types.ObjectId()] });
+    const next = await invoke([ROLE.user, ROLE.parent], parent, { userId: new mongoose.Types.ObjectId().toString() });
+    expect(forbiddenStatus(next)).toBe(403);
+  });
+});

--- a/apps/server/middleware/authMiddleware.ts
+++ b/apps/server/middleware/authMiddleware.ts
@@ -46,7 +46,7 @@ export const protect = asyncHandler(async (req, res, next) => {
       throw new Error('JWT_SECRET is not configured');
     }
 
-    const decoded = jwt.verify(token, process.env.JWT_SECRET) as jwt.JwtPayload;
+    const decoded = jwt.verify(token, process.env.JWT_SECRET, { algorithms: ['HS256'] }) as jwt.JwtPayload;
 
     req.user = (await User.findById(decoded.id).select(EXCLUDED_FIELDS)) ?? undefined;
 
@@ -55,7 +55,9 @@ export const protect = asyncHandler(async (req, res, next) => {
     }
 
     if (parentToken && req.user.roles.includes(ROLE.child)) {
-      const parentDecoded = jwt.verify(parentToken, process.env.JWT_SECRET) as jwt.JwtPayload;
+      const parentDecoded = jwt.verify(parentToken, process.env.JWT_SECRET, {
+        algorithms: ['HS256'],
+      }) as jwt.JwtPayload;
 
       req.parentUser = await User.findById(parentDecoded.id).select(EXCLUDED_FIELDS);
 
@@ -102,8 +104,19 @@ export const authorize = (...roles: Role[]): RequestHandler => {
       }
     }
 
-    // Check if user is accessing their own sandwich
+    /*
+     * Owner access for sandwich-scoped routes ONLY (no :userId param).
+     * The `!userId` guard is critical: on any user-scoped route that also
+     * carried a :sandwichId, a user could otherwise satisfy authorization by
+     * passing a victim's userId together with a sandwichId they own (IDOR).
+     * No route currently combines both params — the former
+     * `/users/:userId/favorite-sandwiches/:sandwichId` route was folded into the
+     * idempotent vote endpoint — so this branch only ever runs for
+     * sandwich-scoped routes. The guard stays as defense-in-depth in case such a
+     * route is reintroduced.
+     */
     if (
+      !userId &&
       sandwichId &&
       Array.isArray(user.sandwiches) &&
       user.sandwiches.some(

--- a/apps/server/middleware/rateLimit.ts
+++ b/apps/server/middleware/rateLimit.ts
@@ -1,0 +1,36 @@
+import { rateLimit } from 'express-rate-limit';
+import logger from '#utils/logger.ts';
+
+/*
+ * Factory for per-IP rate limiters on sensitive endpoints, stricter than the global
+ * API limiter, to blunt credential-stuffing / signup & email-flooding / vote-spam
+ * abuse. They depend on `trust proxy` being set (see server.ts) so the key is the
+ * real client IP, not the upstream gateway. Limits are intentionally tolerant
+ * because a whole household typically shares one public (NAT) IP. The default store
+ * is in-memory (resets on restart) — acceptable for this single-instance deploy.
+ */
+export const createRateLimit = (options: {
+  windowMs: number;
+  max: number;
+  message: string;
+}): ReturnType<typeof rateLimit> =>
+  rateLimit({
+    windowMs: options.windowMs,
+    max: options.max,
+    message: options.message,
+    standardHeaders: true,
+    legacyHeaders: false,
+    handler: (req, res) => {
+      // Log rate limit violation (PII will be automatically masked)
+      logger.warn('Rate limit exceeded', {
+        requestId: req.requestId,
+        ip: req.ip || 'unknown',
+        path: req.path,
+      });
+
+      res.status(429).json({
+        success: false,
+        error: { status: 429, message: options.message },
+      });
+    },
+  });

--- a/apps/server/models/UserModel.ts
+++ b/apps/server/models/UserModel.ts
@@ -32,6 +32,8 @@ export interface IUser {
   children: mongoose.Types.ObjectId[];
   resetPasswordToken?: string;
   resetPasswordExpire?: Date;
+  inviteToken?: string;
+  inviteTokenExpire?: Date;
   emailConfirmed?: boolean;
   emailConfirmationToken?: string;
   emailConfirmationExpire?: Date;
@@ -147,6 +149,12 @@ const userSchema = new Schema<IUser, UserModelType, Record<string, never>, Recor
     ],
     resetPasswordToken: String,
     resetPasswordExpire: Date,
+    inviteToken: {
+      type: String,
+      index: true,
+      sparse: true, // only index documents that have a pending invite token
+    },
+    inviteTokenExpire: Date,
     emailConfirmed: {
       type: Boolean,
       default: false,
@@ -179,6 +187,8 @@ const userSchema = new Schema<IUser, UserModelType, Record<string, never>, Recor
         delete ret.password;
         delete ret.resetPasswordToken;
         delete ret.resetPasswordExpire;
+        delete ret.inviteToken;
+        delete ret.inviteTokenExpire;
         delete ret.emailConfirmationToken;
         delete ret.emailConfirmationExpire;
       },

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -25,6 +25,8 @@
     "lint": "eslint",
     "lint:fix": "eslint --fix",
     "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "init-uploads": "node --env-file ./config/.env service/initUploadsFolder.ts",
     "migrate-email-confirmation-fields": "node --env-file ./config/.env service/migrateEmailConfirmationFields.ts",
     "generate-missing-sandwich-images": "node --env-file ./config/.env service/generateMissingSandwichImages.ts"
@@ -59,6 +61,7 @@
     "@types/morgan": "^1.9.10",
     "@types/multer": "^2.1.0",
     "@types/nodemailer": "^8.0.0",
-    "globals": "^17.6.0"
+    "globals": "^17.6.0",
+    "vitest": "^4.1.7"
   }
 }

--- a/apps/server/routes/authRoutes.ts
+++ b/apps/server/routes/authRoutes.ts
@@ -1,7 +1,12 @@
 import express from 'express';
-import { rateLimit } from 'express-rate-limit';
 import { ROLE } from '@sandwicheck/shared';
-import { createChildUser, getSession, loginChildUser, switchToParent } from '#controllers/authChildController.ts';
+import {
+  createChildUser,
+  createInvite,
+  getSession,
+  loginChildUser,
+  switchToParent,
+} from '#controllers/authChildController.ts';
 import {
   changePassword,
   confirmEmail,
@@ -13,47 +18,53 @@ import {
   signup,
 } from '#controllers/authController.ts';
 import { authorize, protect } from '#middleware/authMiddleware.ts';
-import logger from '#utils/logger.ts';
+import { createRateLimit } from '#middleware/rateLimit.ts';
 
 const router = express.Router();
 
-// Rate limiter for resend confirmation (stricter than general API rate limit)
-const resendConfirmationRateLimit = rateLimit({
+/*
+ * Per-IP rate limiters for sensitive auth endpoints, stricter than the global API
+ * limiter, to blunt credential-stuffing / signup & email-flooding abuse. See
+ * middleware/rateLimit.ts for the shared factory and the trust-proxy / NAT notes.
+ */
+const resendConfirmationRateLimit = createRateLimit({
   windowMs: 60 * 60 * 1000, // 1 hour
-  max: 3, // limit each IP to 3 requests per hour
+  max: 3,
   message: 'Too many confirmation email requests, please try again later',
-  standardHeaders: true,
-  legacyHeaders: false,
-  handler: (req, res) => {
-    // Log rate limit violation (PII will be automatically masked)
-    logger.warn('Rate limit exceeded for resend confirmation', {
-      requestId: req.requestId,
-      ip: req.ip || 'unknown',
-    });
-
-    res.status(429).json({
-      success: false,
-      error: {
-        status: 429,
-        message: 'Too many confirmation email requests, please try again later',
-      },
-    });
-  },
 });
 
-router.post('/signup', signup);
-router.post('/login', login);
+const loginRateLimit = createRateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 20,
+  message: 'Too many login attempts, please try again later',
+});
+
+const signupRateLimit = createRateLimit({
+  windowMs: 60 * 60 * 1000, // 1 hour
+  max: 15,
+  message: 'Too many sign-up attempts, please try again later',
+});
+
+const forgotPasswordRateLimit = createRateLimit({
+  windowMs: 60 * 60 * 1000, // 1 hour
+  max: 10,
+  message: 'Too many password reset requests, please try again later',
+});
+
+router.post('/signup', signupRateLimit, signup);
+router.post('/login', loginRateLimit, login);
 router.get('/session', protect, getSession);
 
 router.get('/confirm-email/:token', confirmEmail);
 router.post('/resend-confirmation', resendConfirmationRateLimit, resendConfirmation);
 
 router.post('/create-child', protect, authorize(ROLE.parent), createChildUser);
+router.post('/create-invite', protect, authorize(ROLE.parent), createInvite);
 router.post('/login-child', protect, authorize(ROLE.parent), loginChildUser);
 router.post('/switch-to-parent', protect, authorize(ROLE.child), switchToParent);
 
 router.put('/change-password', protect, changePassword);
-router.post('/forgot-password', forgotPassword);
+router.post('/forgot-password', forgotPasswordRateLimit, forgotPassword);
 router.put('/reset-password/:resetToken', resetPassword);
 
 router.post('/logout', protect, logout);

--- a/apps/server/routes/sandwichesRoutes.ts
+++ b/apps/server/routes/sandwichesRoutes.ts
@@ -6,7 +6,7 @@ import {
   getSandwich,
   getSandwiches,
   updateSandwich,
-  updateSandwichVotesCount,
+  voteForSandwich,
 } from '#controllers/sandwichesController.ts';
 import { authorize, protect } from '#middleware/authMiddleware.ts';
 
@@ -15,10 +15,12 @@ const router = express.Router({ mergeParams: true });
 
 router.route('/').get(getSandwiches).post(protect, createSandwich);
 
-router
-  .route('/:sandwichId/vote')
-  .post(protect, authorize(ROLE.user), updateSandwichVotesCount)
-  .delete(protect, authorize(ROLE.user), updateSandwichVotesCount);
+/*
+ * Voting requires authentication (but not ownership — you vote on others' sandwiches).
+ * A vote also adds the sandwich to the voter's favorites and is idempotent per user,
+ * so no per-IP rate limit is needed (and one would penalize a NAT household).
+ */
+router.route('/:sandwichId/vote').post(protect, voteForSandwich);
 
 router
   .route('/:sandwichId')

--- a/apps/server/routes/usersRoutes.ts
+++ b/apps/server/routes/usersRoutes.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 import { ROLE } from '@sandwicheck/shared';
-import { deleteUser, getUser, getUsers, updateFavoriteSandwiches, updateUser } from '#controllers/usersController.ts';
+import { deleteUser, getUser, getUsers, updateUser } from '#controllers/usersController.ts';
 import { addSandwichToWeekMenu, removeSandwichFromWeekMenu } from '#controllers/userWeekMenuController.ts';
 import { authorize, protect } from '#middleware/authMiddleware.ts';
 import resizeImage from '#middleware/resizeMiddleware.ts';
@@ -15,11 +15,6 @@ export const uploadImage = upload.single('profilePicture');
 router.route('/').get(protect, authorize(ROLE.admin), getUsers);
 
 router.route('/current').get(protect, getUser);
-
-router
-  .route('/:userId/favorite-sandwiches/:sandwichId')
-  .post(protect, authorize(ROLE.user), updateFavoriteSandwiches)
-  .delete(protect, authorize(ROLE.user), updateFavoriteSandwiches);
 
 router
   .route('/:userId/week-menu/:day')

--- a/apps/server/server.ts
+++ b/apps/server/server.ts
@@ -5,6 +5,7 @@ import cookieParser from 'cookie-parser';
 import cors from 'cors';
 import helmet from 'helmet';
 import hpp from 'hpp';
+import createHttpError from 'http-errors';
 import morgan from 'morgan';
 import connectDB from './config/db.ts';
 import { CLIENT_DIR, UPLOADS_DIR } from './config/dir.ts';
@@ -17,6 +18,16 @@ import usersRoutes from './routes/usersRoutes.ts';
 import logger, { getLoggerLevel, morganStream } from './utils/logger.ts';
 
 const app = express();
+
+/*
+ * ==== Trust proxy ==== //
+ * The app runs behind a single nginx reverse proxy (container bound to 127.0.0.1).
+ * Trust exactly one hop so `req.ip` and express-rate-limit keys resolve to the real
+ * client IP from `X-Forwarded-For` instead of the upstream/gateway address.
+ * NOTE: do NOT use `true` here — it would let clients spoof X-Forwarded-For and
+ * bypass IP-based rate limiting. Increase the number if more proxies are added.
+ */
+app.set('trust proxy', 1);
 
 // Rate limiter
 app.use(
@@ -112,8 +123,8 @@ app.use('/api/v1/sandwiches', sandwichesRoutes);
 app.use('/api/v1/auth', authRoutes);
 app.use('/api/v1/users', usersRoutes);
 
-// === Middleware === //
-app.use(errorHandler);
+// Unknown API routes return a JSON 404 instead of falling through to the SPA static handler
+app.use('/api', (req, res, next) => next(createHttpError.NotFound('Route not found')));
 
 /*
  * === Forward static content === //
@@ -122,6 +133,9 @@ app.use(errorHandler);
 app.use('/', express.static(CLIENT_DIR));
 // Uploads folder
 app.use('/uploads', express.static(UPLOADS_DIR));
+
+// === Error handler (must be registered last so it catches errors from all routes) === //
+app.use(errorHandler);
 
 // Start server
 const PORT = process.env.PORT || 5001;

--- a/apps/server/service/migrateEmailConfirmationFields.ts
+++ b/apps/server/service/migrateEmailConfirmationFields.ts
@@ -34,6 +34,7 @@
  * - Consider running during maintenance window
  */
 
+import mongoose from 'mongoose';
 import connectDB from '#config/db.ts';
 import User from '#models/UserModel.ts';
 import logger from '#utils/logger.ts';
@@ -80,11 +81,19 @@ const migrateEmailConfirmationFields = async (): Promise<void> => {
       logger.warn('⚠ Warning: Some users may still be confirmed.');
     }
 
-    throw new Error('Migration completed successfully');
+    logger.info('Migration completed successfully.');
   } catch (error) {
     logger.error('Migration failed:', error);
     throw error;
   }
 };
 
-await migrateEmailConfirmationFields();
+try {
+  await migrateEmailConfirmationFields();
+} finally {
+  /*
+   * Close the connection so the process can exit on its own — 0 on success, or
+   * non-zero when the migration rethrew (the error is already logged above).
+   */
+  await mongoose.disconnect();
+}

--- a/apps/server/utils/hashAndTokens.ts
+++ b/apps/server/utils/hashAndTokens.ts
@@ -15,6 +15,21 @@ export const generateResetPasswordToken = (): string => {
   return crypto.randomBytes(20).toString('hex');
 };
 
+/*
+ * Hash a high-entropy random token (reset-password / email-confirmation / parent
+ * invite) for storage. The raw token is emailed/linked; only this digest is stored,
+ * so a DB leak never exposes a usable token. A 160-bit `randomBytes` token needs no
+ * per-token salt (salting defends low-entropy passwords against rainbow tables —
+ * bcrypt already does that for our passwords); plain SHA-256 is the standard here.
+ *
+ * TOKEN_HASH_PEPPER is an OPTIONAL, server-side global pepper for defense-in-depth:
+ * a DB leak alone can't be matched against tokens without it. It is a DEDICATED
+ * secret, deliberately separate from JWT_SECRET so the two rotate independently and
+ * a single leak doesn't compromise both. Unset → empty pepper → a no-op, so local
+ * dev / CI need no config; set a value in production to enable it. Changing the
+ * pepper invalidates any unredeemed tokens (acceptable — users just request a new one).
+ */
 export const hashToken = (token: string): string => {
-  return crypto.createHash('sha256').update(token).digest('hex');
+  const pepper = process.env.TOKEN_HASH_PEPPER ?? '';
+  return crypto.createHash('sha256').update(`${pepper}${token}`).digest('hex');
 };

--- a/apps/server/utils/manageUserConnections.ts
+++ b/apps/server/utils/manageUserConnections.ts
@@ -11,8 +11,13 @@ export const removeUserConnections = async (
   connectionId?: ConnectionId,
 ): Promise<{ error: string } | undefined> => {
   const oppositeField = field === 'parents' ? 'children' : 'parents';
-  const connectionRole = field === 'parents' ? ROLE.parent : ROLE.parent;
-  const selfRole = field === 'parents' ? ROLE.parent : ROLE.parent;
+  /*
+   * Role to remove from the *connection* once it has no reciprocal links left:
+   * unlinking parents may demote a parent; unlinking children may demote a child.
+   */
+  const connectionRole = field === 'parents' ? ROLE.parent : ROLE.child;
+  // Role to remove from *this user* once their own field becomes empty.
+  const selfRole = field === 'parents' ? ROLE.child : ROLE.parent;
   // List of ids from a field or a specific id
   const ids = connectionId ? [connectionId] : user[field];
 

--- a/eslint.base.js
+++ b/eslint.base.js
@@ -198,6 +198,28 @@ export default defineConfig([
       'import/resolver': {
         typescript: {
           alwaysTryTypes: true,
+          /*
+           * Point the resolver at every workspace package's tsconfig by ABSOLUTE
+           * path (import.meta.dirname is this repo root, since eslint.base.js lives
+           * here). Without an explicit `project`, the TypeScript resolver only finds
+           * a tsconfig relative to cwd — so it picks up each package's `paths`
+           * (e.g. the client's `@/*`) when eslint runs from that package
+           * (`pnpm --filter ... lint`) but NOT when it runs from the repo root.
+           * The lefthook pre-commit hook runs `eslint {staged_files}` from the root,
+           * which previously produced false-positive `import/no-unresolved` errors
+           * on `@/` value imports.
+           *
+           * These are EXACT absolute paths, not globs: glob patterns are matched
+           * relative to cwd, so an absolute glob escapes cwd and matches nothing
+           * when eslint runs from inside a package (breaking the per-package lint).
+           * Exact paths are loaded directly and stay cwd-independent either way.
+           */
+          project: [
+            `${import.meta.dirname}/apps/client/tsconfig.json`,
+            `${import.meta.dirname}/apps/server/tsconfig.json`,
+            `${import.meta.dirname}/packages/shared/tsconfig.json`,
+          ],
+          noWarnOnMultipleProjects: true,
         },
         node: {
           extensions: ['.js', '.jsx', '.ts', '.tsx'],

--- a/packages/shared/src/types/dto.ts
+++ b/packages/shared/src/types/dto.ts
@@ -16,13 +16,20 @@ export interface SignupDto {
   password?: string;
   /** Validated at runtime to be `child` or `parent`. */
   role?: string;
-  parentId?: string;
+  /** Single-use parent invite token (replaces the previous unauthenticated parentId linking). */
+  inviteToken?: string;
 }
 
 export interface LoginDto {
   email?: string;
   password?: string;
-  parentId?: string;
+  /** Parent invite token; links the account to the inviting parent on login. */
+  inviteToken?: string;
+}
+
+/** Response payload for POST /auth/create-invite. */
+export interface CreateInviteData {
+  token: string;
 }
 
 export interface ChangePasswordDto {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -280,6 +280,9 @@ importers:
       globals:
         specifier: ^17.6.0
         version: 17.6.0
+      vitest:
+        specifier: ^4.1.7
+        version: 4.1.7(@types/node@25.9.1)(jsdom@28.1.0)(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0)(yaml@2.9.0))
 
   packages/shared: {}
 


### PR DESCRIPTION
## Summary

Hardens the SandwiCheck server/client ahead of production and reworks voting so it
requires an account and stays coupled to favorites. The branch was regrouped from its
original WIP history into 7 scope-grouped commits (infra → auth → voting → tests →
docs → 2 fixes).

## Voting (registered-only, = favorites)
- Voting now **requires authentication**. A logged-out click opens a signup prompt
  instead of casting a vote.
- A vote **adds the sandwich to the voter's favorites** and bumps `votesCount` in a
  single call. The favorites set is the idempotency gate, so re-voting is a harmless
  no-op (counts once per user, never over-counts).
- Removed the anonymous-voting infrastructure (IP/UA fingerprint, `Vote` collection,
  per-IP vote rate limit) and the now-redundant standalone favorites endpoint, which
  could desync `votesCount`.
- Client: single coupled call with optimistic UI update; removed the logged-out
  `localStorage` vote tracking and the dual favorite+vote requests.

## Auth & security
- **IDOR fix:** owner-access authorization no longer applies on routes carrying a
  `:userId` param, closing a privilege-escalation path (act on a victim's record using
  a sandwich you own).
- **JWT algorithm pinning** (`HS256`) on verification to prevent algorithm-confusion.
- **Consent-based invitations:** replaced the old `parentId`-in-body linking (which let
  a caller link to *any* user) with single-use, hashed, expiring invite tokens. A parent
  generates an invite link; it links exactly one child on first redemption and is then
  consumed. Linking is best-effort — signup/login still succeed on an expired/used link.
- **Password reset:** reject a non-string `newPassword` and enforce the same 5–30 length
  policy as signup/change-password.
- **bcrypt cost factor** defaults to 10 when `BCRYPT_SALT_ROUNDS` is unset/blank
  (previously produced `NaN` rounds).
- **Email XSS:** escape user-controlled names before interpolating into HTML email bodies.
- **Optional token pepper** (`TOKEN_HASH_PEPPER`): a dedicated, separate-from-`JWT_SECRET`
  global pepper mixed into reset/confirmation/invite token hashing. Unset = no-op, so it's
  zero-config for dev/CI and opt-in for production. Does not affect passwords.
- **Per-IP rate limiting** on login, signup, forgot-password, and resend-confirmation via
  a shared factory.
- Fixed a role-demotion bug in connection management (parent/child roles were collapsed).

## Server bootstrap & input hardening
- `trust proxy = 1` (single nginx hop) so client IP / rate-limit keys resolve correctly
  without allowing `X-Forwarded-For` spoofing.
- Error handler registered last; unknown `/api` routes now return a JSON 404 instead of
  falling through to the SPA static handler.
- Explicit database selection via `MONGO_DB_NAME` (no hardcoded default) with a production
  warning if the implicit `test` database is in use.
- NoSQL-injection hardening: coerce ingredient query params to strings before use.
- Migration script no longer "throws on success" and now closes its DB connection cleanly.

## Client UI
- Signup prompt is rendered at the app level (survives being triggered from inside the
  sandwich detail modal, e.g. via a WhatsApp share link).
- Family page: generate / copy / send a fresh single-use invite link, with copy
  guidance ("each link invites one child; generating a new link replaces the previous one").

## Tests, CI & docs
- New server vitest harness with regression tests for the authorization IDOR fix and the
  email HTML-escaping; server tests added to CI.
- `.env.example` documents all environment variables (DB name, invite token lifetime,
  token pepper, script flags, logging).
- ESLint resolver fix so root-run lint (lefthook pre-commit) resolves workspace `@/` and
  `#` aliases without false `import/no-unresolved` errors.

## Migration / ops notes
- No data migration required. The orphaned anonymous-vote collection can be dropped
  manually (optional); existing `votesCount` values are preserved.
- Set `MONGO_DB_NAME` (or a `/<db>` path in `MONGO_URI`) in production to avoid the
  implicit `test` database. `TOKEN_HASH_PEPPER` is optional.

## Verification
- `pnpm typecheck`, server tests (12), client tests (2), `pnpm lint` — all green.
- `pnpm knip` shows no new dead code (only pre-existing baseline findings).
