### PR TITLE
fix(server,client): resolve security & correctness audit findings

### DIFF
--- a/apps/client/src/components/Sandwich/SandwichModal.tsx
+++ b/apps/client/src/components/Sandwich/SandwichModal.tsx
@@ -11,7 +11,6 @@ interface SandwichModalProps {
 }
 
 const SandwichModal = ({ closeLink = '' }: SandwichModalProps): React.JSX.Element | null => {
-  const [isModalLoading, setIsModalLoading] = useState(true);
   // Decorative card background, chosen once per mount so it stays stable across re-renders (keeps render pure).
   const [cardBackgroundIndex] = useState(() => Math.ceil(Math.random() * 4));
   const { areIngredientsReady } = useIngredientsGlobalContext();
@@ -23,17 +22,20 @@ const SandwichModal = ({ closeLink = '' }: SandwichModalProps): React.JSX.Elemen
 
   useEffect(() => {
     if (!sandwichId) return;
-
-    void (async () => {
-      await getSandwich(sandwichId);
-
-      if (areIngredientsReady) setIsModalLoading(false);
-    })();
-  }, [areIngredientsReady, getSandwich, sandwichId]);
+    void getSandwich(sandwichId);
+  }, [getSandwich, sandwichId]);
 
   if (!sandwichId) {
     return null;
   }
+
+  /*
+   * Derive loading instead of tracking it in state: show the loader until the sandwich has
+   * loaded AND ingredients are ready to hydrate the card. The previous effect only cleared a
+   * loading flag when ingredients happened to be ready as the fetch resolved, so a late
+   * ingredients load left it stuck until a redundant re-fetch.
+   */
+  const isModalLoading = !sandwich || !areIngredientsReady;
 
   return (
     <Modal modalId="sandwich" isModalLoading={isModalLoading} closeLink={closeLink}>

--- a/apps/client/src/hooks/use-user.ts
+++ b/apps/client/src/hooks/use-user.ts
@@ -81,7 +81,14 @@ const useUser = (): UseUserResult => {
      * Only set currentUser and loggedIn if email confirmation is not required.
      * Check if response has a message about checking email.
      */
-    const needsEmailConfirmation = res.message && res.message.includes('check your email');
+    /*
+     * Signup never auto-authenticates (email confirmation is required first), so don't
+     * trigger a session refresh when the account was created but not logged in — whether
+     * confirmation is pending or the confirmation email failed to send.
+     */
+    const needsEmailConfirmation =
+      res.message &&
+      (res.message.includes('check your email') || res.message.includes('confirmation email could not be sent'));
     if (needsEmailConfirmation) {
       applySession(null);
       setIsCurrentUserReady(true);

--- a/apps/server/constants/excludeFields.ts
+++ b/apps/server/constants/excludeFields.ts
@@ -1,4 +1,4 @@
 const EXCLUDED_FIELDS =
-  '-password -resetPasswordToken -resetPasswordExpire -emailConfirmationToken -emailConfirmationExpire';
+  '-password -resetPasswordToken -resetPasswordExpire -inviteToken -inviteTokenExpire -emailConfirmationToken -emailConfirmationExpire';
 
 export default EXCLUDED_FIELDS;

--- a/apps/server/controllers/authController.ts
+++ b/apps/server/controllers/authController.ts
@@ -99,6 +99,21 @@ export const signup = asyncHandler<ParamsDictionary, unknown, SignupDto>(async (
 
     await userExists.save();
 
+    /*
+     * Link the parent invite token here too: this branch returns before the
+     * post-creation linking below, so without it a child re-signing up through an
+     * invite link (after an earlier unconfirmed attempt) would never be linked.
+     */
+    if (inviteToken) {
+      const linked = await linkParentByInviteToken(userExists, inviteToken);
+      if (!linked) {
+        logger.warn('Signup (existing unconfirmed account) used an invalid or expired invite token', {
+          requestId: req.requestId,
+          userId: userExists._id.toString(),
+        });
+      }
+    }
+
     const confirmationURL = `${process.env.CLIENT_URL}/confirm-email/${confirmationToken}`;
 
     try {
@@ -284,7 +299,7 @@ export const login = asyncHandler<ParamsDictionary, unknown, LoginDto>(async (re
 export const changePassword = asyncHandler<ParamsDictionary, unknown, ChangePasswordDto>(async (req, res, next) => {
   const { oldPassword, newPassword } = req.body;
 
-  const user = await User.findById(req.user!.id);
+  const user = await User.findById(req.user!.id).select('+password');
 
   if (!user) {
     return next(createHttpError.NotFound('User not found'));

--- a/apps/server/controllers/usersController.ts
+++ b/apps/server/controllers/usersController.ts
@@ -4,6 +4,7 @@ import bcrypt from 'bcryptjs';
 import createHttpError from 'http-errors';
 import type mongoose from 'mongoose';
 import { PROFILE_PICTURES_DIR } from '#config/dir.ts';
+import EXCLUDED_FIELDS from '#constants/excludeFields.ts';
 import {
   generateChildActivationHtml,
   generateChildActivationText,
@@ -26,7 +27,7 @@ import { removeUserConnections } from '#utils/manageUserConnections.ts';
  * @access  Private/Admin
  */
 export const getUsers = asyncHandler(async (req, res, _next) => {
-  const users = await User.find({});
+  const users = await User.find({}).select(EXCLUDED_FIELDS);
   res.status(200).json({ success: true, data: users });
 });
 
@@ -40,7 +41,11 @@ export const getUser = asyncHandler(async (req, res, next) => {
   // current user or another userID
   const userId = req.params.userId || req.user!.id;
 
-  const user = await User.findById(userId).populate('sandwiches').populate('parents').populate('children');
+  const user = await User.findById(userId)
+    .select(EXCLUDED_FIELDS)
+    .populate('sandwiches')
+    .populate('parents', EXCLUDED_FIELDS)
+    .populate('children', EXCLUDED_FIELDS);
 
   if (!user) {
     return next(createHttpError.NotFound('User not found'));

--- a/apps/server/middleware/uploadMiddleware.ts
+++ b/apps/server/middleware/uploadMiddleware.ts
@@ -6,7 +6,8 @@ import multer from 'multer';
 const storage = multer.memoryStorage();
 
 const fileFilter = (req: Request, file: Express.Multer.File, cb: FileFilterCallback): void => {
-  const filetypes = /jpeg|jpg|png/;
+  // Anchor to the full MIME type so values like "application/jpeg-x" or "x/png" can't pass.
+  const filetypes = /^image\/(jpe?g|png)$/;
   const mimetype = filetypes.test(file.mimetype);
 
   if (mimetype) {
@@ -18,7 +19,8 @@ const fileFilter = (req: Request, file: Express.Multer.File, cb: FileFilterCallb
 };
 
 const limits = {
-  fileSize: Number.parseInt(process.env.MAX_UPLOAD_SIZE_IN_BYTES ?? '', 10),
+  // Default to 10MB when the env var is unset/invalid, so a misconfig can't disable the cap (NaN = no limit).
+  fileSize: Number.parseInt(process.env.MAX_UPLOAD_SIZE_IN_BYTES ?? '', 10) || 10_485_760,
 };
 
 const upload = multer({ storage, limits, fileFilter });

--- a/apps/server/models/UserModel.ts
+++ b/apps/server/models/UserModel.ts
@@ -100,6 +100,7 @@ const userSchema = new Schema<IUser, UserModelType, Record<string, never>, Recor
     password: {
       type: String,
       required: [checkChildWithoutEmail, 'Password is required '],
+      select: false, // never loaded by default; auth paths opt in via .select('+password')
     },
     isTetheredChild: {
       type: Boolean,

--- a/apps/server/routes/authRoutes.ts
+++ b/apps/server/routes/authRoutes.ts
@@ -51,11 +51,18 @@ const forgotPasswordRateLimit = createRateLimit({
   message: 'Too many password reset requests, please try again later',
 });
 
+// Token-gated endpoints (email confirmation, password reset) — defense-in-depth atop the high-entropy tokens.
+const tokenVerificationRateLimit = createRateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 30,
+  message: 'Too many attempts, please try again later',
+});
+
 router.post('/signup', signupRateLimit, signup);
 router.post('/login', loginRateLimit, login);
 router.get('/session', protect, getSession);
 
-router.get('/confirm-email/:token', confirmEmail);
+router.get('/confirm-email/:token', tokenVerificationRateLimit, confirmEmail);
 router.post('/resend-confirmation', resendConfirmationRateLimit, resendConfirmation);
 
 router.post('/create-child', protect, authorize(ROLE.parent), createChildUser);
@@ -65,7 +72,7 @@ router.post('/switch-to-parent', protect, authorize(ROLE.child), switchToParent)
 
 router.put('/change-password', protect, changePassword);
 router.post('/forgot-password', forgotPasswordRateLimit, forgotPassword);
-router.put('/reset-password/:resetToken', resetPassword);
+router.put('/reset-password/:resetToken', tokenVerificationRateLimit, resetPassword);
 
 router.post('/logout', protect, logout);
 

--- a/apps/server/server.ts
+++ b/apps/server/server.ts
@@ -42,8 +42,15 @@ app.use(
 app.use(
   cors({
     origin: (origin, callback) => {
-      const isOriginAllowed = process.env.CLIENT_URL === origin || !origin;
-      callback(null, process.env.NODE_ENV === 'local' || isOriginAllowed);
+      /*
+       * Enforce the CLIENT_URL allowlist (and same-origin / no-origin requests). In local
+       * dev, additionally allow any localhost origin — but never reflect an arbitrary origin
+       * back with credentials, which the previous `NODE_ENV === 'local' || ...` did.
+       */
+      const isLocalhost = !!origin && /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/.test(origin);
+      const isAllowed =
+        !origin || process.env.CLIENT_URL === origin || (process.env.NODE_ENV === 'local' && isLocalhost);
+      callback(null, isAllowed);
     },
     credentials: true,
   }),

--- a/apps/server/utils/manageUserConnections.ts
+++ b/apps/server/utils/manageUserConnections.ts
@@ -21,8 +21,12 @@ export const removeUserConnections = async (
   // List of ids from a field or a specific id
   const ids = connectionId ? [connectionId] : user[field];
 
-  // Prevent unlinking a parent from a tethered child (no email)
-  if (field === 'parents' && user.isTetheredChild) {
+  /*
+   * Prevent unlinking a parent from a tethered child (no email) via a targeted unlink.
+   * The `connectionId` guard lets bulk teardown (no id, e.g. account deletion) proceed,
+   * so deleting a tethered child still clears its id from every parent's children array.
+   */
+  if (connectionId && field === 'parents' && user.isTetheredChild) {
     return {
       error: `This account is connected to the ${connectionRole} you're attempting to unlink. To detach the account, please add an email address`,
     };


### PR DESCRIPTION
A repo-wide audit (auth, injection, data-exposure, correctness) surfaced several latent issues remaining after the hardening rework. This resolves every actionable one in a single pass; no behaviour change for valid flows.

Data-exposure / hardening (server):
- UserModel: mark `password` select:false so the hash is never loaded by default — redaction no longer depends solely on the toJSON transform (.lean()/.toObject() are covered too). login already opted in via .select('+password'); changePassword now does the same.
- excludeFields: add inviteToken/inviteTokenExpire (the select deny-list had drifted from the toJSON strip-list when invite tokens were introduced).
- usersController: project EXCLUDED_FIELDS in getUser/getUsers (and the populated parents/children), matching populateUserSessionData — default-deny instead of serializer-dependent.
- uploadMiddleware: anchor the image MIME check to /^image\/(jpe?g|png)$/ and default the size cap to 10MB, so an unset MAX_UPLOAD_SIZE_IN_BYTES (NaN) can no longer disable the limit.
- server: in CORS, allow only localhost origins in local dev instead of reflecting any origin with credentials; other envs keep the CLIENT_URL allowlist.
- authRoutes: rate-limit the confirm-email and reset-password token endpoints (defense-in-depth atop the high-entropy tokens).

Correctness:
- manageUserConnections: skip the tethered-child unlink guard during bulk teardown (no connectionId) so deleting a tethered child no longer leaves dangling ids in its parents' children arrays.
- authController: link the parent invite token when an existing *unconfirmed* account re-signs up (that branch returned before the linking step).
- SandwichModal (client): derive the loading flag from (sandwich && ingredients) instead of a state flag cleared only when ingredients happened to be ready as the fetch resolved — fixes a stuck loader and a redundant re-fetch.
- use-user (client): treat the "confirmation email could not be sent" signup response as needing confirmation (no bogus session refresh), mirroring use-form.

Investigated, intentionally NOT changed:
- "child -> parent role change" is not a privilege escalation: signup already accepts role:parent publicly, a parent is sandboxed to its own family, and tethered children are blocked from converting.